### PR TITLE
gemspec: Drop executables directive

### DIFF
--- a/resolv-replace.gemspec
+++ b/resolv-replace.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "resolv"


### PR DESCRIPTION
This gem exposes no executables.