### PR TITLE
Handle keyword arguments in TCPSocket#initialize

### DIFF
--- a/lib/resolv-replace.rb
+++ b/lib/resolv-replace.rb
@@ -20,9 +20,9 @@ class TCPSocket < IPSocket
   # :stopdoc:
   alias original_resolv_initialize initialize
   # :startdoc:
-  def initialize(host, serv, *rest)
+  def initialize(host, serv, *rest, **kwargs)
     rest[0] = IPSocket.getaddress(rest[0]) if rest[0]
-    original_resolv_initialize(IPSocket.getaddress(host), serv, *rest)
+    original_resolv_initialize(IPSocket.getaddress(host), serv, *rest, **kwargs)
   end
 end
 


### PR DESCRIPTION
Fixes https://github.com/ruby/resolv-replace/issues/2.

This method takes a `connect_timeout` keyword argument since Ruby 3.0, which needs to be passed through to the original implementation.